### PR TITLE
WebSocket.close doesn't like passing null arguments

### DIFF
--- a/lib/html.dart
+++ b/lib/html.dart
@@ -105,7 +105,15 @@ class HtmlWebSocketChannel extends StreamChannelMixin
   /// Pipes user events to [_webSocket].
   void _listen() {
     _controller.local.stream.listen((message) => _webSocket.send(message),
-        onDone: () => _webSocket.close(_localCloseCode, _localCloseReason));
+        onDone: () {
+      if (_localCloseCode != null && _localCloseReason != null) {
+        _webSocket.close(_localCloseCode, _localCloseReason);
+      } else if (_localCloseCode != null) {
+        _webSocket.close(_localCloseCode);
+      } else {
+        _webSocket.close();
+      }
+    });
   }
 }
 


### PR DESCRIPTION
Looks like it is internally checking for arguments length. Always crashes with:
```
InvalidAccessError: Failed to execute 'close' on 'WebSocket': The code must be either 1000, or between 3000 and 4999. 0 is neither.
```

Chrome Version 51.0.2704.19 dev-m (64-bit)
