### PR TITLE
add library names; increase the sdk constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.5
+
+* Increase the SDK version constraint to `<2.0.0-dev.infinity`.
+
 ## 1.0.4
 
 * Support `crypto` 2.0.0.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,2 @@
+analyzer:
+  strong-mode: true

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+library web_socket_channel.html;
+
 import 'dart:async';
 import 'dart:html';
 import 'dart:typed_data';

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -2,6 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+library web_socket_channel.io;
+
 import 'dart:async';
 import 'dart:io';
 

--- a/lib/src/copy/web_socket_impl.dart
+++ b/lib/src/copy/web_socket_impl.dart
@@ -58,18 +58,6 @@ class _WebSocketOpcode {
 }
 
 /**
- *  Stores the header and integer value derived from negotiation of
- *  client_max_window_bits and server_max_window_bits. headerValue will be
- *  set in the Websocket response headers.
- */
-class _CompressionMaxWindowBits {
-  String headerValue;
-  int maxWindowBits;
-  _CompressionMaxWindowBits([this.headerValue, this.maxWindowBits]);
-  String toString() => headerValue;
-}
-
-/**
  * The web socket protocol transformer handles the protocol byte stream
  * which is supplied through the [:handleData:]. As the protocol is processed,
  * it'll output frame data as either a List<int> or String.

--- a/lib/status.dart
+++ b/lib/status.dart
@@ -16,6 +16,8 @@
 ///   channel.close(status.goingAway);
 /// }
 /// ```
+library web_socket_channel.status;
+
 import 'dart:core';
 
 /// The purpose for which the connection was established has been fulfilled.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: web_socket_channel
-version: 1.0.5-dev
+version: 1.0.5
 description: StreamChannel wrappers for WebSockets.
 author: Dart Team <misc@dartlang.org>
 homepage: https://github.com/dart-lang/web_socket_channel
 
 environment:
-  sdk: '>=1.13.0 <2.0.0'
+  sdk: '>=1.13.0 <2.0.0-dev.infinity'
 
 dependencies:
   async: '^1.3.0'


### PR DESCRIPTION
- add library names (fix the appearance in https://docs.flutter.io/)
- increase the sdk constraint to `<2.0.0-dev.infinity`

@nex3 @kevmoo 

(I think we'll want to publish this version after this lands; looks like only @nex3 is a publisher, which we'll probably want to expand a bit)