### PR TITLE
Fix sample code in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/status.dart' as status;
 
 main() async {
-  var channel = await IOWebSocketChannel.connect("ws://localhost:1234");
+  var channel = IOWebSocketChannel.connect("ws://localhost:1234");
 
   channel.stream.listen((message) {
     channel.sink.add("received!");
-    channel.close(status.goingAway);
+    channel.sink.close(status.goingAway);
   });
 }
 ```


### PR DESCRIPTION
The `.close()` method is on `.sink` so this code didn't compile. The `await` also appeared to be unnecessary.