### PR TITLE
Add a WebSocketChannel.ready field and a timeout parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## UNRELEASED
+
+* Add a WebSocketChannel.ready field that indicates if connection with ws has been established
+* Add a timeout parameter for a WebSocket connection
+
 ## 1.0.13
 
 * Internal changes for consistency with the Dart SDK.


### PR DESCRIPTION
'ready' future indicates if the connection has been established.
It completes on successful connection to the websocket.

Closes #25

Also adds a `timeout` parameter for a `connect` method to make it possible to timeout a connection after a certain amount of time.

Not the cleanest solution probably I guess. But seems to be working and it's something I need (and maybe other ppl might need) for my project.