### PR TITLE
Update to handle Socket implements Stream<Uint8List>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.14
+
+* Updates to handle `Socket implements Stream<Uint8List>`
+
 ## 1.0.13
 
 * Internal changes for consistency with the Dart SDK.

--- a/lib/src/copy/web_socket_impl.dart
+++ b/lib/src/copy/web_socket_impl.dart
@@ -607,7 +607,7 @@ class _WebSocketConsumer implements StreamConsumer {
         onResume: _onResume,
         onCancel: _onListen);
     var stream =
-        _controller.stream.transform(_WebSocketOutgoingTransformer(webSocket));
+        _WebSocketOutgoingTransformer(webSocket).bind(_controller.stream);
     sink.addStream(stream).then((_) {
       _done();
       _closeCompleter.complete(webSocket);
@@ -709,7 +709,7 @@ class WebSocketImpl extends Stream with _ServiceObject implements StreamSink {
     _readyState = WebSocket.OPEN;
 
     var transformer = _WebSocketProtocolTransformer(_serverSide);
-    _subscription = stream.transform(transformer).listen((data) {
+    _subscription = transformer.bind(stream).listen((data) {
       if (data is _WebSocketPing) {
         if (!_writeClosed) _consumer.add(_WebSocketPong(data.payload));
       } else if (data is _WebSocketPong) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 1.0.13
+version: 1.0.14
 
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform


### PR DESCRIPTION
A recent change in the Dart SDK updated `Socket` to
implement `Stream<Uint8List>` rather than `Stream<List<int>>`.
This forwards compatible change calls `StreamTransformer.bind()`
rather than `Stream.transform()`, thus putting the stream in a
covariant position and allowing for the transition to `Uint8List`.

https://github.com/dart-lang/sdk/issues/36900