### PR TITLE
Add `WebSocketChannel.connect` factory constructor.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0
+
+* Add `WebSocketChannel.connect` factory constructor supporting platform
+  independent creation of WebSockets providing the lowest common denominator
+  of support on dart:io and dart:html.
+
 ## 1.0.15
 
 * bug fix don't pass protocols parameter to WebSocket.

--- a/lib/src/_connect_api.dart
+++ b/lib/src/_connect_api.dart
@@ -6,9 +6,8 @@ import '../web_socket_channel.dart';
 
 /// Creates a new WebSocket connection.
 ///
-/// Connects to [url] using and returns a channel that can be used to
-/// communicate over the resulting socket. The [url] may be either a [String]
-/// or a [Uri].
-WebSocketChannel connect(String url) {
+/// Connects to [uri] using and returns a channel that can be used to
+/// communicate over the resulting socket.
+WebSocketChannel connect(Uri uri) {
   throw UnsupportedError('No implementation of the connect api provided');
 }

--- a/lib/src/_connect_api.dart
+++ b/lib/src/_connect_api.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../web_socket_channel.dart';
+
+/// Creates a new WebSocket connection.
+///
+/// Connects to [url] using and returns a channel that can be used to
+/// communicate over the resulting socket. The [url] may be either a [String]
+/// or a [Uri].
+WebSocketChannel connect(String url) {
+  throw UnsupportedError('No implementation of the connect api provided');
+}

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -8,7 +8,6 @@ import '../web_socket_channel.dart';
 
 /// Creates a new WebSocket connection.
 ///
-/// Connects to [url] using and returns a channel that can be used to
-/// communicate over the resulting socket. The [url] may be either a [String]
-/// or a [Uri].
-WebSocketChannel connect(url) => HtmlWebSocketChannel.connect(url);
+/// Connects to [uri] using and returns a channel that can be used to
+/// communicate over the resulting socket.
+WebSocketChannel connect(Uri uri) => HtmlWebSocketChannel.connect(uri);

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -1,0 +1,14 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:web_socket_channel/html.dart';
+
+import '../web_socket_channel.dart';
+
+/// Creates a new WebSocket connection.
+///
+/// Connects to [url] using and returns a channel that can be used to
+/// communicate over the resulting socket. The [url] may be either a [String]
+/// or a [Uri].
+WebSocketChannel connect(url) => HtmlWebSocketChannel.connect(url);

--- a/lib/src/_connect_io.dart
+++ b/lib/src/_connect_io.dart
@@ -1,0 +1,13 @@
+// Copyright (c) 2019, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import '../web_socket_channel.dart';
+import '../io.dart';
+
+/// Creates a new WebSocket connection.
+///
+/// Connects to [url] using and returns a channel that can be used to
+/// communicate over the resulting socket. The [url] may be either a [String]
+/// or a [Uri].
+WebSocketChannel connect(url) => IOWebSocketChannel.connect(url);

--- a/lib/src/_connect_io.dart
+++ b/lib/src/_connect_io.dart
@@ -7,7 +7,6 @@ import '../io.dart';
 
 /// Creates a new WebSocket connection.
 ///
-/// Connects to [url] using and returns a channel that can be used to
-/// communicate over the resulting socket. The [url] may be either a [String]
-/// or a [Uri].
-WebSocketChannel connect(url) => IOWebSocketChannel.connect(url);
+/// Connects to [uri] using and returns a channel that can be used to
+/// communicate over the resulting socket
+WebSocketChannel connect(Uri uri) => IOWebSocketChannel.connect(uri);

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -101,10 +101,9 @@ class WebSocketChannel extends StreamChannelMixin {
 
   /// Creates a new WebSocket connection.
   ///
-  /// Connects to [url] using and returns a channel that can be used to
-  /// communicate over the resulting socket. The [url] may be either a [String]
-  /// or a [Uri].
-  factory WebSocketChannel.connect(url) => platform.connect(url);
+  /// Connects to [uri] using and returns a channel that can be used to
+  /// communicate over the resulting socket.
+  factory WebSocketChannel.connect(Uri uri) => platform.connect(uri);
 }
 
 /// The sink exposed by a [WebSocketChannel].

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -11,6 +11,10 @@ import 'package:stream_channel/stream_channel.dart';
 
 import 'copy/web_socket_impl.dart';
 
+import '_connect_api.dart'
+    if (dart.library.io) '_connect_io.dart'
+    if (dart.library.html) '_connect_html.dart' as platform;
+
 /// A [StreamChannel] that communicates over a WebSocket.
 ///
 /// This is implemented by classes that use `dart:io` and `dart:html`. The [new
@@ -94,6 +98,13 @@ class WebSocketChannel extends StreamChannelMixin {
       : _webSocket = WebSocketImpl.fromSocket(
             channel.stream, channel.sink, protocol, serverSide)
           ..pingInterval = pingInterval;
+
+  /// Creates a new WebSocket connection.
+  ///
+  /// Connects to [url] using and returns a channel that can be used to
+  /// communicate over the resulting socket. The [url] may be either a [String]
+  /// or a [Uri].
+  factory WebSocketChannel.connect(url) => platform.connect(url);
 }
 
 /// The sink exposed by a [WebSocketChannel].

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 1.0.15
+version: 1.1.0
 
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform

--- a/test/html_test.dart
+++ b/test/html_test.dart
@@ -79,6 +79,18 @@ void main() {
     expect(await queue.next, equals([1, 2, 3, 4, 5]));
   });
 
+  test(".connect defaults to binary lists using platform independent api",
+      () async {
+    channel = WebSocketChannel.connect("ws://localhost:$port");
+
+    var queue = StreamQueue(channel.stream);
+    channel.sink.add("foo");
+    expect(await queue.next, equals("foo"));
+
+    channel.sink.add(Uint8List.fromList([1, 2, 3, 4, 5]));
+    expect(await queue.next, equals([1, 2, 3, 4, 5]));
+  });
+
   test(".connect can use blobs", () async {
     channel = HtmlWebSocketChannel.connect("ws://localhost:$port",
         binaryType: BinaryType.blob);

--- a/test/html_test.dart
+++ b/test/html_test.dart
@@ -81,7 +81,7 @@ void main() {
 
   test(".connect defaults to binary lists using platform independent api",
       () async {
-    channel = WebSocketChannel.connect("ws://localhost:$port");
+    channel = WebSocketChannel.connect(Uri.parse("ws://localhost:$port"));
 
     var queue = StreamQueue(channel.stream);
     channel.sink.add("foo");

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -81,7 +81,8 @@ void main() {
       });
     });
 
-    var channel = WebSocketChannel.connect("ws://localhost:${server.port}");
+    var channel =
+        WebSocketChannel.connect(Uri.parse("ws://localhost:${server.port}"));
     channel.sink.add("ping");
 
     channel.stream.listen(


### PR DESCRIPTION
This supports platform independent creation of WebSockets providing
the lowest common denominator of support on dart:io and dart:html.