### PR TITLE
Added optional [protocols] argument to [WebSocketChannel.connect]

### DIFF
--- a/lib/src/_connect_api.dart
+++ b/lib/src/_connect_api.dart
@@ -8,6 +8,8 @@ import '../web_socket_channel.dart';
 ///
 /// Connects to [uri] using and returns a channel that can be used to
 /// communicate over the resulting socket.
-WebSocketChannel connect(Uri uri) {
+///
+/// The optional [protocols] parameter is the same as [WebSocket.connect].
+WebSocketChannel connect(Uri uri, {Iterable<String> protocols}) {
   throw UnsupportedError('No implementation of the connect api provided');
 }

--- a/lib/src/_connect_html.dart
+++ b/lib/src/_connect_html.dart
@@ -10,4 +10,7 @@ import '../web_socket_channel.dart';
 ///
 /// Connects to [uri] using and returns a channel that can be used to
 /// communicate over the resulting socket.
-WebSocketChannel connect(Uri uri) => HtmlWebSocketChannel.connect(uri);
+///
+/// The optional [protocols] parameter is the same as [WebSocket.connect].
+WebSocketChannel connect(Uri uri, {Iterable<String> protocols}) =>
+    HtmlWebSocketChannel.connect(uri, protocols: protocols);

--- a/lib/src/_connect_io.dart
+++ b/lib/src/_connect_io.dart
@@ -8,5 +8,8 @@ import '../io.dart';
 /// Creates a new WebSocket connection.
 ///
 /// Connects to [uri] using and returns a channel that can be used to
-/// communicate over the resulting socket
-WebSocketChannel connect(Uri uri) => IOWebSocketChannel.connect(uri);
+/// communicate over the resulting socket.
+///
+/// The optional [protocols] parameter is the same as [WebSocket.connect].
+WebSocketChannel connect(Uri uri, {Iterable<String> protocols}) =>
+    IOWebSocketChannel.connect(uri, protocols: protocols);

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -105,7 +105,10 @@ class WebSocketChannel extends StreamChannelMixin {
   ///
   /// Connects to [uri] using and returns a channel that can be used to
   /// communicate over the resulting socket.
-  factory WebSocketChannel.connect(Uri uri) => platform.connect(uri);
+  ///
+  /// The optional [protocols] parameter is the same as [WebSocket.connect].
+  factory WebSocketChannel.connect(Uri uri, {Iterable<String> protocols}) =>
+      platform.connect(uri, protocols: protocols);
 }
 
 /// The sink exposed by a [WebSocketChannel].


### PR DESCRIPTION
This small PR adds an optional named argument to `WebSocketChannel.connect` so that it can pass custom socket protocols to the underlying platform specific implementation (both `HtmlWebSocketChannel` and `IOWebSocketChannel` supports it).