### PR TITLE
Add a language version tag in spawnHybridUri

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-- 2.0.0
+- 2.10.0
 - dev
 
 dart_task:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
 homepage: https://github.com/dart-lang/web_socket_channel
 
 environment:
-  sdk: ">=2.0.0 <3.0.0"
+  sdk: ">=2.10.0 <3.0.0"
 
 dependencies:
   async: ">=1.3.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,4 +17,4 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.0.0
-  test: ^1.2.0
+  test: ^1.16.0-nullsafety

--- a/test/html_test.dart
+++ b/test/html_test.dart
@@ -18,7 +18,7 @@ void main() {
   int port;
   setUpAll(() async {
     var channel = spawnHybridCode(r'''
-      // @dart=2.17
+      // @dart=2.7
       import 'dart:io';
 
       import 'package:stream_channel/stream_channel.dart';

--- a/test/html_test.dart
+++ b/test/html_test.dart
@@ -18,6 +18,7 @@ void main() {
   int port;
   setUpAll(() async {
     var channel = spawnHybridCode(r'''
+      // @dart=2.17
       import 'dart:io';
 
       import 'package:stream_channel/stream_channel.dart';


### PR DESCRIPTION
Code snippets passed to `spawnHybridCode` are currently always run with
the SDK language version. Add an explicit language version marker so
that this test is stable.