### PR TITLE
Allow the null safe package:crypto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 1.2.0-dev
+## 1.2.0
 
 * Add `protocols` argument to `WebSocketChannel.connect`. See the docs for
   `WebSocket.connet`.
+* Allow the latest crypto release (`3.x`).
 
 ## 1.1.0
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 1.2.0-dev
+version: 1.2.0
 
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   async: ">=1.3.0 <3.0.0"
-  crypto: ">=0.9.2 <3.0.0"
+  crypto: ">=0.9.2 <4.0.0"
   stream_channel: ">=1.2.0 <3.0.0"
 
 dev_dependencies:


### PR DESCRIPTION
A local pub solve still won't pick it up due to a transitive constraint
from `analyzer` as a dev_dependency.