### PR TITLE
[Ping Interval] Allow control over websocket ping interval

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -28,6 +28,10 @@ class IOWebSocketChannel extends StreamChannelMixin
   @override
   String get closeReason => _webSocket?.closeReason;
 
+  set pingInterval(Duration _pingInterval) {
+    _webSocket?.pingInterval = _pingInterval;
+  }
+
   @override
   final Stream stream;
   @override


### PR DESCRIPTION
Hi,

The suggested PR allows control over the websocket ping interval even after the websocket was created.
This is useful in some cases when ping interval is to be disabled temporarily.

Thanks!