### PR TITLE
switch to universal_io package in place of dart:io

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -3,10 +3,10 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:stream_channel/stream_channel.dart';
+import 'package:universal_io/io.dart';
 
 import 'src/channel.dart';
 import 'src/exception.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   async: ^2.5.0
   crypto: ^3.0.0
   stream_channel: ^2.1.0
+  universal_io: ^2.0.4
 
 dev_dependencies:
   pedantic: ^1.10.0


### PR DESCRIPTION
When I publish my package [obs_websocket](https://pub.dev/packages/obs_websocket) the analyzer flags web_socket_channel for using the dart:io package, which is incompatible with the 'js' runtime platform.  This PR replaces the **dart:io** package with **universal_io**

![Screen Shot 2021-06-11 at 4 39 32 PM](https://user-images.githubusercontent.com/923202/121746260-9dd7ae00-cad3-11eb-9bc6-73c6b6bc240d.png)
