### PR TITLE
Allow specifying a custom client for IOWebSockets

### DIFF
--- a/lib/io.dart
+++ b/lib/io.dart
@@ -62,12 +62,17 @@ class IOWebSocketChannel extends StreamChannelMixin
     Iterable<String>? protocols,
     Map<String, dynamic>? headers,
     Duration? pingInterval,
+    HttpClient? customClient,
   }) {
     late IOWebSocketChannel channel;
     final sinkCompleter = WebSocketSinkCompleter();
     final stream = StreamCompleter.fromFuture(
-      WebSocket.connect(url.toString(), headers: headers, protocols: protocols)
-          .then((webSocket) {
+      WebSocket.connect(
+        url.toString(),
+        headers: headers,
+        protocols: protocols,
+        customClient: customClient,
+      ).then((webSocket) {
         webSocket.pingInterval = pingInterval;
         channel._webSocket = webSocket;
         sinkCompleter.setDestinationSink(_IOWebSocketSink(webSocket));


### PR DESCRIPTION
Modifying `HttpClient` settings can be very useful in a development environment.

Specifically, I'm looking to specify a proxy server to use in order to be able to inspect the WS network traffic. Others may be interested in allowing invalid certificates to be used.

I'm aware of #211, but it seems that has stalled. I figured I could provide a smaller diff and see if that can help to get this upstreamed.