### PR TITLE
Allow passing through custom http client in IO socket connect

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [2.12.0, dev]
+        sdk: [2.15.0, dev]
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
       - uses: dart-lang/setup-dart@a57a6c04cf7d4840e88432aad6281d1e125f0d46

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.4.0
+- Adds a `customClient` parameter to the `IOWebSocketChannel.connect` factory,
+  which allows the user to provide a custom `HttpClient` instance to use for the
+  WebSocket connection
+
 ## 2.3.0
 
 - Added a Future `ready` property to `WebSocketChannel`, which completes when

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 ## 2.4.0
-- Adds a `customClient` parameter to the `IOWebSocketChannel.connect` factory,
+
+- Add a `customClient` parameter to the `IOWebSocketChannel.connect` factory,
   which allows the user to provide a custom `HttpClient` instance to use for the
   WebSocket connection
-- Bumps minimum Dart version to 2.15.0
+- Bump minimum Dart version to 2.15.0
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 - Adds a `customClient` parameter to the `IOWebSocketChannel.connect` factory,
   which allows the user to provide a custom `HttpClient` instance to use for the
   WebSocket connection
-- Minimum dart version bumped to 2.15.0
+- Bumps minimum Dart version to 2.15.0
 
 ## 2.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 - Adds a `customClient` parameter to the `IOWebSocketChannel.connect` factory,
   which allows the user to provide a custom `HttpClient` instance to use for the
   WebSocket connection
+- Minimum dart version bumped to 2.15.0
 
 ## 2.3.0
 

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -74,6 +74,7 @@ class IOWebSocketChannel extends StreamChannelMixin
     Map<String, dynamic>? headers,
     Duration? pingInterval,
     Duration? connectTimeout,
+    HttpClient? customClient
   }) {
     late IOWebSocketChannel channel;
     final sinkCompleter = WebSocketSinkCompleter();
@@ -81,6 +82,7 @@ class IOWebSocketChannel extends StreamChannelMixin
       url.toString(),
       headers: headers,
       protocols: protocols,
+      customClient: customClient,
     );
     if (connectTimeout != null) {
       future = future.timeout(connectTimeout);

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -74,7 +74,7 @@ class IOWebSocketChannel extends StreamChannelMixin
     Map<String, dynamic>? headers,
     Duration? pingInterval,
     Duration? connectTimeout,
-    HttpClient? customClient
+    HttpClient? customClient,
   }) {
     late IOWebSocketChannel channel;
     final sinkCompleter = WebSocketSinkCompleter();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,7 @@ description: >-
 repository: https://github.com/dart-lang/web_socket_channel
 
 environment:
-  sdk: ">=2.12.0 <3.0.0"
+  sdk: ">=2.15.0 <3.0.0"
 
 dependencies:
   async: ^2.5.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 2.3.0
+version: 2.4.0
 
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -236,15 +236,11 @@ void main() {
     server
         .transform(StreamTransformer<HttpRequest, HttpRequest>.fromHandlers(
           handleData: (data, sink) {
-            expect(data.headers['user-agent'], 'custom');
+            expect(data.headers['user-agent'], ['custom']);
             sink.add(data);
           },
         ))
-        .transform(WebSocketTransformer())
-        .listen((webSocket) {
-          final channel = IOWebSocketChannel(webSocket);
-          channel.stream.drain();
-        });
+        .transform(WebSocketTransformer());
 
     final channel = IOWebSocketChannel.connect(
       'ws://localhost:${server.port}',
@@ -252,6 +248,5 @@ void main() {
     );
 
     expect(channel.ready, completes);
-    await channel.sink.close();
   });
 }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -229,4 +229,29 @@ void main() {
     expect(channel.ready, throwsA(isA<TimeoutException>()));
     expect(channel.stream.drain(), throwsA(isA<WebSocketChannelException>()));
   });
+
+  test('.custom client is passed through', () async {
+    server = await HttpServer.bind('localhost', 0);
+    addTearDown(server.close);
+    server
+        .transform(StreamTransformer<HttpRequest, HttpRequest>.fromHandlers(
+          handleData: (data, sink) {
+            expect(data.headers['user-agent'], 'custom');
+            sink.add(data);
+          },
+        ))
+        .transform(WebSocketTransformer())
+        .listen((webSocket) {
+          final channel = IOWebSocketChannel(webSocket);
+          channel.stream.drain();
+        });
+
+    final channel = IOWebSocketChannel.connect(
+      'ws://localhost:${server.port}',
+      customClient: HttpClient()..userAgent = 'custom',
+    );
+
+    expect(channel.ready, completes);
+    await channel.sink.close();
+  });
 }

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -233,14 +233,12 @@ void main() {
   test('.custom client is passed through', () async {
     server = await HttpServer.bind('localhost', 0);
     addTearDown(server.close);
-    server
-        .transform(StreamTransformer<HttpRequest, HttpRequest>.fromHandlers(
-          handleData: (data, sink) {
-            expect(data.headers['user-agent'], ['custom']);
-            sink.add(data);
-          },
-        ))
-        .transform(WebSocketTransformer());
+    server.transform(StreamTransformer<HttpRequest, HttpRequest>.fromHandlers(
+      handleData: (data, sink) {
+        expect(data.headers['user-agent'], ['custom']);
+        sink.add(data);
+      },
+    )).transform(WebSocketTransformer());
 
     final channel = IOWebSocketChannel.connect(
       'ws://localhost:${server.port}',


### PR DESCRIPTION
I am using a service that is very strict about user agents. Passing a user agent into the `headers` field doesn't work because this code adds headers instead of replacing them.

https://github.com/dart-lang/sdk/blob/83b7f7c2ac2df0a375387dc1017f6c96ccbcaccc/sdk/lib/_http/websocket_impl.dart#L1029

This PR allows passing in a custom http client to resolve the issue