### PR TITLE
Fix deprecated_new_in_comment_reference

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -31,7 +31,6 @@ linter:
   - file_names
   - hash_and_equals
   - implementation_imports
-  - invariant_booleans
   - iterable_contains_unrelated_type
   - join_return_with_assignment
   - lines_longer_than_80_chars

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -62,10 +62,10 @@ class HtmlWebSocketChannel extends StreamChannelMixin
 
   /// Creates a new WebSocket connection.
   ///
-  /// Connects to [url] using [new WebSocket] and returns a channel that can be
+  /// Connects to [url] using [WebSocket.new] and returns a channel that can be
   /// used to communicate over the resulting socket. The [url] may be either a
   /// [String] or a [Uri]. The [protocols] parameter is the same as for
-  /// [new WebSocket].
+  /// [WebSocket.new].
   ///
   /// The [binaryType] parameter controls what type is used for binary messages
   /// received by this socket. It defaults to [BinaryType.list], which causes

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -17,9 +17,9 @@ import 'exception.dart';
 
 /// A [StreamChannel] that communicates over a WebSocket.
 ///
-/// This is implemented by classes that use `dart:io` and `dart:html`. The [new
-/// WebSocketChannel] constructor can also be used on any platform to connect to
-/// use the WebSocket protocol over a pre-existing channel.
+/// This is implemented by classes that use `dart:io` and `dart:html`.
+/// The [WebSocketChannel.new] constructor can also be used on any platform to
+/// connect to use the WebSocket protocol over a pre-existing channel.
 ///
 /// All implementations emit [WebSocketChannelException]s. These exceptions wrap
 /// the native exception types where possible.


### PR DESCRIPTION
Switch to `ClassName.new` constructor tearoff syntax instead of the deprecated `new ClassName`.

Remove reference to deprecated lint `invariant_booleans`.