### PR TITLE
Make it more clear how `WebSocketChannel.ready` should be used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.4.1
+
+- Update the examples to use `WebSocketChannel.ready` and clarify that
+  `WebSocketChannel.ready` should be awaited before sending data over the
+  `WebSocketChannel`.
+
 ## 2.4.0
 
 - Add a `customClient` parameter to the `IOWebSocketChannel.connect` factory,

--- a/README.md
+++ b/README.md
@@ -24,8 +24,10 @@ import 'package:web_socket_channel/web_socket_channel.dart';
 import 'package:web_socket_channel/status.dart' as status;
 
 main() async {
-  final wsUrl = Uri.parse('ws://localhost:1234')
-  var channel = WebSocketChannel.connect(wsUrl);
+  final wsUrl = Uri.parse('ws://example.com')
+  final channel = WebSocketChannel.connect(wsUrl);
+
+  await channel.ready;
 
   channel.stream.listen((message) {
     channel.sink.add('received!');

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,11 +2,14 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:web_socket_channel/io.dart';
 import 'package:web_socket_channel/status.dart' as status;
+import 'package:web_socket_channel/web_socket_channel.dart';
 
-void main() {
-  final channel = IOWebSocketChannel.connect('ws://localhost:1234');
+void main() async {
+  final wsUrl = Uri.parse('ws://example.com');
+  final channel = WebSocketChannel.connect(wsUrl);
+
+  await channel.ready;
 
   channel.stream.listen((message) {
     channel.sink.add('received!');

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -51,8 +51,31 @@ class WebSocketChannel extends StreamChannelMixin {
   /// Before the connection has been closed, this will be `null`.
   String? get closeReason => _webSocket.closeReason;
 
-  /// Future indicating if the connection has been established.
-  /// It completes on successful connection to the websocket.
+  /// A future that will complete when the WebSocket connection has been
+  /// established.
+  ///
+  /// This future must be complete before before data can be sent using
+  /// [WebSocketChannel.sink].
+  ///
+  /// If a connection could not be established (e.g. because of a network
+  /// issue), then this future will complete with an error.
+  ///
+  /// For example:
+  /// ```
+  /// final channel = WebSocketChannel.connect(Uri.parse('ws://example.com'));
+  ///
+  /// try {
+  ///   await channel.ready;
+  /// } on SocketException catch (e) {
+  ///   // Handle the exception.
+  /// } on WebSocketChannelException catch (e) {
+  ///   // Handle the exception.
+  /// }
+  ///
+  /// // If `ready` completes without an error then the channel is ready to
+  /// // send data.
+  /// channel.sink.add('Hello World');
+  /// ```
   final Future<void> ready = Future.value();
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 2.4.0
+version: 2.4.1
 
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform


### PR DESCRIPTION
- Update the examples
- Updated the docs for [WebSocketChannel.ready]

Fixes https://github.com/dart-lang/web_socket_channel/issues/229
Fixes https://github.com/dart-lang/web_socket_channel/issues/249
Fixes https://github.com/dart-lang/web_socket_channel/issues/267

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
