### PR TITLE
Add a note explaining why the onerror doesn't generate detailed exception

### DIFF
--- a/lib/html.dart
+++ b/lib/html.dart
@@ -99,6 +99,8 @@ class HtmlWebSocketChannel extends StreamChannelMixin
     // The socket API guarantees that only a single error event will be emitted,
     // and that once it is no open or message events will be emitted.
     innerWebSocket.onError.first.then((_) {
+      // Unfortunately, the underlying WebSocket API doesn't expose any
+      // specific information about the error itself.
       final error = WebSocketChannelException('WebSocket connection failed.');
       _readyCompleter.completeError(error);
       _controller.local.sink.addError(error);


### PR DESCRIPTION

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
