### PR TITLE
Mention `ready` in the docs for `connect`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - Update the examples to use `WebSocketChannel.ready` and clarify that
   `WebSocketChannel.ready` should be awaited before sending data over the
   `WebSocketChannel`.
-- Mention `ready` in the docs for `conenct`.
+- Mention `ready` in the docs for `connect`.
 
 ## 2.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 2.4.1
+## 2.4.1-wip
 
 - Update the examples to use `WebSocketChannel.ready` and clarify that
   `WebSocketChannel.ready` should be awaited before sending data over the
   `WebSocketChannel`.
+- Mention `ready` in the docs for `conenct`.
 
 ## 2.4.0
 

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -134,6 +134,12 @@ class WebSocketChannel extends StreamChannelMixin {
   /// communicate over the resulting socket.
   ///
   /// The optional [protocols] parameter is the same as `WebSocket.connect`.
+  ///
+  /// A WebSocketChannel is returned synchronously, however the connection is
+  /// not established synchronously.
+  /// The [ready] future will complete after the channel is connected.
+  /// If there are errors creating the connection the [ready] future will
+  /// complete as an error.
   factory WebSocketChannel.connect(Uri uri, {Iterable<String>? protocols}) =>
       platform.connect(uri, protocols: protocols);
 }

--- a/lib/src/channel.dart
+++ b/lib/src/channel.dart
@@ -139,7 +139,7 @@ class WebSocketChannel extends StreamChannelMixin {
   /// not established synchronously.
   /// The [ready] future will complete after the channel is connected.
   /// If there are errors creating the connection the [ready] future will
-  /// complete as an error.
+  /// complete with an error.
   factory WebSocketChannel.connect(Uri uri, {Iterable<String>? protocols}) =>
       platform.connect(uri, protocols: protocols);
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 2.4.1
+version: 2.4.1-wip
 
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform


### PR DESCRIPTION
Closes #280

Errors during connection can cause confusion because they escape a try
block unless there is an `await channel.ready`. Mention that `ready` can
complete as an error in the case of connection failure.
