### PR TITLE
adjust the HtmlWebSocketChannel ctor parameter type; rev to 2.4.3

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -42,7 +42,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        sdk: [3.2.0, dev]
+        sdk: [3.2, dev]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
       - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
@@ -60,3 +60,12 @@ jobs:
       - name: Run Chrome tests - wasm
         run: dart test --platform chrome --compiler dart2wasm
         if: always() && steps.install.outcome == 'success' && matrix.sdk == 'dev'
+
+  # Run analysis against the oldest supported pub constraints.
+  downgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
+      - uses: dart-lang/setup-dart@b64355ae6ca0b5d484f0106a033dd1388965d06d
+      - run: dart pub downgrade
+      - run: dart analyze --fatal-infos

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
+## 2.4.3
+
+- `HtmlWebSocketChannel`: Relax the type of the websocket parameter to the
+  constructor in order to mitigate a breaking change introduced in `2.4.1`.
+
 ## 2.4.2
+
 - Allow `web: '>=0.3.0 <0.5.0'`
 
 ## 2.4.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 - `HtmlWebSocketChannel`: Relax the type of the websocket parameter to the
   constructor in order to mitigate a breaking change introduced in `2.4.1`.
 
-## 2.4.2
+## 2.4.2 (retracted)
 
 - Allow `web: '>=0.3.0 <0.5.0'`
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,13 @@
 [![CI](https://github.com/dart-lang/web_socket_channel/actions/workflows/test-package.yml/badge.svg?branch=master)](https://github.com/dart-lang/web_socket_channel/actions/workflows/test-package.yml)
+[![pub package](https://img.shields.io/pub/v/web_socket_channel.svg)](https://pub.dev/packages/web_socket_channel)
+[![package publisher](https://img.shields.io/pub/publisher/web_socket_channel.svg)](https://pub.dev/packages/web_socket_channel/publisher)
 
-The `web_socket_channel` package provides [`StreamChannel`][stream_channel]
-wrappers for WebSocket connections. It provides a cross-platform
+`package:web_socket_channel` provides cross-platform
+[`StreamChannel`][stream_channel] wrappers for WebSocket connections.
+
+## Docs and Usage
+
+It provides a cross-platform
 [`WebSocketChannel`][WebSocketChannel] API, a cross-platform implementation of
 that API that communicates over an underlying [`StreamChannel`][stream_channel],
 [an implementation][IOWebSocketChannel] that wraps `dart:io`'s `WebSocket`

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -82,8 +82,12 @@ class HtmlWebSocketChannel extends StreamChannelMixin
           )..binaryType = (binaryType ?? BinaryType.list).value,
         );
 
-  /// Creates a channel wrapping [innerWebSocket].
-  HtmlWebSocketChannel(this.innerWebSocket) {
+  /// Creates a channel wrapping [webSocket].
+  ///
+  /// The parameter [webSocket] should be either a dart:html `WebSocket`
+  /// instance or a package:web [WebSocket] instance.
+  HtmlWebSocketChannel(Object /*WebSocket*/ webSocket)
+      : innerWebSocket = webSocket as WebSocket {
     _readyCompleter = Completer();
     if (innerWebSocket.readyState == WebSocket.OPEN) {
       _readyCompleter.complete();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,5 @@
 name: web_socket_channel
-version: 2.4.2
-
+version: 2.4.3
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform
   WebSocketChannel API, a cross-platform implementation of that API that
@@ -14,7 +13,7 @@ dependencies:
   async: ^2.5.0
   crypto: ^3.0.0
   stream_channel: ^2.1.0
-  web: '>=0.3.0 <0.5.0'
+  web: ^0.4.0
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0


### PR DESCRIPTION
- rev to `2.4.3`
- have the CI also test using `dart pub downgrade`
- `HtmlWebSocketChannel`: Relax the type of the websocket parameter to the constructor in order to mitigate a breaking change introduced in `2.4.1`.
- restrict the `package:web` dependency to `^0.4.0`

In future major versions of this package, we'd likely re-introduce a type annotation for HtmlWebSocketChannel constructor.

---

- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
