### PR TITLE
Implement IOWebSocketChannel as a WebSocketAdapterWebSocket subclass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
   default implementation for `WebSocketChannel.connect`.
 - **BREAKING**: Remove `WebSocketChannel` constructor.
 - **BREAKING**: Make `WebSocketChannel` an `abstract interface`.
+- **BREAKING**: `IOWebSocketChannel.ready` will throw
+  `WebSocketChannelException` instead of `WebSocketException`.
 
 ## 2.4.5
 

--- a/lib/web_socket_adapter_web_socket_channel.dart
+++ b/lib/web_socket_adapter_web_socket_channel.dart
@@ -66,14 +66,19 @@ class WebSocketAdapterWebSocketChannel extends StreamChannelMixin
   /// future will complete with an error.
   factory WebSocketAdapterWebSocketChannel.connect(Uri url,
           {Iterable<String>? protocols}) =>
-      WebSocketAdapterWebSocketChannel._(
+      WebSocketAdapterWebSocketChannel(
           WebSocket.connect(url, protocols: protocols));
 
-  // Create a [WebSocketWebSocketChannelAdapter] from an existing [WebSocket].
-  factory WebSocketAdapterWebSocketChannel.fromWebSocket(WebSocket webSocket) =>
-      WebSocketAdapterWebSocketChannel._(Future.value(webSocket));
+  // Construct a [WebSocketWebSocketChannelAdapter] from an existing
+  // [WebSocket].
+  WebSocketAdapterWebSocketChannel(FutureOr<WebSocket> webSocket) {
+    late Future<WebSocket> webSocketFuture;
+    if (webSocket is WebSocket) {
+      webSocketFuture = Future.value(webSocket);
+    } else {
+      webSocketFuture = webSocket;
+    }
 
-  WebSocketAdapterWebSocketChannel._(Future<WebSocket> webSocketFuture) {
     webSocketFuture.then((webSocket) {
       var remoteClosed = false;
       webSocket.events.listen((event) {
@@ -113,7 +118,16 @@ class WebSocketAdapterWebSocketChannel extends StreamChannelMixin
       _protocol = webSocket.protocol;
       _readyCompleter.complete();
     }, onError: (Object e) {
-      _readyCompleter.completeError(WebSocketChannelException.from(e));
+      late Exception error;
+      if (e is TimeoutException) {
+        // Required for backwards compatibility with `IOWebSocketChannel`.
+        error = e;
+      } else {
+        error = WebSocketChannelException.from(e);
+      }
+      _readyCompleter.completeError(error);
+      _controller.local.sink.addError(error);
+      _controller.local.sink.close();
     });
   }
 }

--- a/lib/web_socket_adapter_web_socket_channel.dart
+++ b/lib/web_socket_adapter_web_socket_channel.dart
@@ -72,7 +72,7 @@ class WebSocketAdapterWebSocketChannel extends StreamChannelMixin
   // Construct a [WebSocketWebSocketChannelAdapter] from an existing
   // [WebSocket].
   WebSocketAdapterWebSocketChannel(FutureOr<WebSocket> webSocket) {
-    late Future<WebSocket> webSocketFuture;
+    Future<WebSocket> webSocketFuture;
     if (webSocket is WebSocket) {
       webSocketFuture = Future.value(webSocket);
     } else {
@@ -118,7 +118,7 @@ class WebSocketAdapterWebSocketChannel extends StreamChannelMixin
       _protocol = webSocket.protocol;
       _readyCompleter.complete();
     }, onError: (Object e) {
-      late Exception error;
+      Exception error;
       if (e is TimeoutException) {
         // Required for backwards compatibility with `IOWebSocketChannel`.
         error = e;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   crypto: ^3.0.0
   stream_channel: ^2.1.0
   web: ^0.5.0
-  web_socket: ^0.1.0
+  web_socket: ^0.1.5
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   crypto: ^3.0.0
   stream_channel: ^2.1.0
   web: ^0.5.0
-  web_socket: ^0.1.5
+  web_socket: ^0.1.1
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0

--- a/test/io_test.dart
+++ b/test/io_test.dart
@@ -131,7 +131,7 @@ void main() {
     });
 
     final channel = IOWebSocketChannel.connect('ws://localhost:${server.port}');
-    expect(channel.ready, throwsA(isA<WebSocketException>()));
+    expect(channel.ready, throwsA(isA<WebSocketChannelException>()));
     expect(channel.stream.drain<void>(),
         throwsA(isA<WebSocketChannelException>()));
   });
@@ -154,7 +154,7 @@ void main() {
       'ws://localhost:${server.port}',
       protocols: [failedProtocol],
     );
-    expect(channel.ready, throwsA(isA<WebSocketException>()));
+    expect(channel.ready, throwsA(isA<WebSocketChannelException>()));
     expect(
       channel.stream.drain<void>(),
       throwsA(isA<WebSocketChannelException>()),
@@ -230,8 +230,7 @@ void main() {
     );
 
     expect(channel.ready, throwsA(isA<TimeoutException>()));
-    expect(channel.stream.drain<void>(),
-        throwsA(isA<WebSocketChannelException>()));
+    expect(channel.stream.drain<void>(), throwsA(anything));
   });
 
   test('.custom client is passed through', () async {

--- a/test/web_socket_adapter_web_socket_test.dart
+++ b/test/web_socket_adapter_web_socket_test.dart
@@ -112,9 +112,26 @@ void main() {
       expect(channel.closeReason, null);
     });
 
-    test('fromWebSocket', () async {
+    test('constructor with WebSocket', () async {
       final webSocket = await WebSocket.connect(uri);
-      final channel = WebSocketAdapterWebSocketChannel.fromWebSocket(webSocket);
+      final channel = WebSocketAdapterWebSocketChannel(webSocket);
+
+      await expectLater(channel.ready, completes);
+      channel.sink.add('This count says:');
+      channel.sink.add([1, 2, 3]);
+      channel.sink.add('And then:');
+      channel.sink.add([4, 5, 6]);
+      expect(await channel.stream.take(4).toList(), [
+        'This count says:',
+        [1, 2, 3],
+        'And then:',
+        [4, 5, 6]
+      ]);
+    });
+
+    test('constructor with Future<WebSocket>', () async {
+      final webSocketFuture = WebSocket.connect(uri);
+      final channel = WebSocketAdapterWebSocketChannel(webSocketFuture);
 
       await expectLater(channel.ready, completes);
       channel.sink.add('This count says:');


### PR DESCRIPTION
See [Simplify the web_socket_channel implementation](https://github.com/dart-lang/web_socket_channel/issues/340)

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
