### PR TITLE
Deprecate the constructors for `HtmlWebSocketChannel` and `IOWebSocketChannel`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 - **BREAKING**: Make `WebSocketChannel` an `abstract interface`.
 - **BREAKING**: `IOWebSocketChannel.ready` will throw
   `WebSocketChannelException` instead of `WebSocketException`.
+- `HtmlWebSocketChannel.connect` is deprecated, use `WebSocketChannel.connect`
+  instead.
+- Deprecated the `HtmlWebSocketChannel` constructor, use
+  `WebSocketChannel.connect` instead.
 
 ## 2.4.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,10 @@
 - **BREAKING**: Make `WebSocketChannel` an `abstract interface`.
 - **BREAKING**: `IOWebSocketChannel.ready` will throw
   `WebSocketChannelException` instead of `WebSocketException`.
-- `HtmlWebSocketChannel.connect` is deprecated, use `WebSocketChannel.connect`
-  instead.
-- Deprecated the `HtmlWebSocketChannel` constructor, use
-  `WebSocketChannel.connect` instead.
+- `HtmlWebSocketChannel.connect` is deprecated.
+- The `HtmlWebSocketChannel` constructor is deprecated.
+- `IOWebSocketChannel.connect` is deprecated.
+- The `IOWebSocketChannel` constructor is deprecated.
 
 ## 2.4.5
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ It provides a cross-platform
 that API that communicates over an underlying [`StreamChannel`][stream_channel],
 [an implementation][IOWebSocketChannel] that wraps `dart:io`'s `WebSocket`
 class, and [a similar implementation][HtmlWebSocketChannel] that wraps
-`dart:html`'s.
+`package:web`'s.
 
 [stream_channel]: https://pub.dev/packages/stream_channel
 [WebSocketChannel]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel-class.html
@@ -27,7 +27,6 @@ import this library with the prefix `status`.
 
 ```dart
 import 'package:web_socket_channel/web_socket_channel.dart';
-import 'package:web_socket_channel/status.dart' as status;
 
 main() async {
   final wsUrl = Uri.parse('ws://example.com');
@@ -37,7 +36,7 @@ main() async {
 
   channel.stream.listen((message) {
     channel.sink.add('received!');
-    channel.sink.close(status.goingAway);
+    channel.sink.close();
   });
 }
 ```

--- a/example/example.dart
+++ b/example/example.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:web_socket_channel/status.dart' as status;
 import 'package:web_socket_channel/web_socket_channel.dart';
 
 void main() async {
@@ -13,6 +12,6 @@ void main() async {
 
   channel.stream.listen((message) {
     channel.sink.add('received!');
-    channel.sink.close(status.goingAway);
+    channel.sink.close();
   });
 }

--- a/lib/html.dart
+++ b/lib/html.dart
@@ -72,6 +72,7 @@ class HtmlWebSocketChannel extends StreamChannelMixin
   /// received by this socket. It defaults to [BinaryType.list], which causes
   /// binary messages to be delivered as [Uint8List]s. If it's
   /// [BinaryType.blob], they're delivered as [Blob]s instead.
+  @Deprecated('Use WebSocketChannel.connect() instead')
   HtmlWebSocketChannel.connect(Object url,
       {Iterable<String>? protocols, BinaryType? binaryType})
       : this(
@@ -85,6 +86,7 @@ class HtmlWebSocketChannel extends StreamChannelMixin
   ///
   /// The parameter [webSocket] should be either a dart:html `WebSocket`
   /// instance or a package:web [WebSocket] instance.
+  @Deprecated('Use WebSocketChannel.connect() instead')
   HtmlWebSocketChannel(Object /*WebSocket*/ webSocket)
       : innerWebSocket = webSocket as WebSocket {
     _readyCompleter = Completer();

--- a/lib/io.dart
+++ b/lib/io.dart
@@ -33,6 +33,35 @@ class IOWebSocketChannel extends AdapterWebSocketChannel {
   ///
   /// If there's an error connecting, the channel's stream emits a
   /// [WebSocketChannelException] wrapping that error and then closes.
+  ///
+  /// **DEPRECATED**: Instead of using this method, use [IOWebSocket] with
+  /// [AdapterWebSocketChannel]. For example:
+  ///
+  /// ```dart
+  /// import 'dart:io' show WebSocket;
+  ///
+  /// import 'package:web_socket/io_web_socket.dart' show IOWebSocket;
+  /// import 'package:web_socket_channel/adapter_web_socket_channel.dart';
+  ///
+  /// void main() async {
+  ///   final ioWebSocket = await WebSocket.connect('<url>', protocols: [
+  ///     'chatV1',
+  ///     'chatV2',
+  ///   ], headers: {
+  ///     'authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXV',
+  ///   }).timeout(const Duration(milliseconds: 500));
+  ///
+  ///   ioWebSocket.pingInterval = const Duration(seconds: 10);
+  ///
+  ///   final channel =
+  ///       AdapterWebSocketChannel(IOWebSocket.fromWebSocket(ioWebSocket));
+  ///
+  ///   await channel.ready;
+  ///
+  ///   // Use the `WebSocketChannel`.
+  /// }
+  /// ```
+  @Deprecated('Use IOWebSocket with AdapterWebSocketChannel')
   factory IOWebSocketChannel.connect(
     Object url, {
     Iterable<String>? protocols,
@@ -56,6 +85,36 @@ class IOWebSocketChannel extends AdapterWebSocketChannel {
   }
 
   /// Creates a channel wrapping [webSocket].
+  ///
+  /// **DEPRECATED**: Instead, use [IOWebSocket] with [AdapterWebSocketChannel].
+  ///
+  /// For example:
+  ///
+  /// ```dart
+  /// import 'dart:io' show WebSocket;
+  ///
+  /// import 'package:web_socket/io_web_socket.dart' show IOWebSocket;
+  /// import 'package:web_socket_channel/adapter_web_socket_channel.dart';
+  ///
+  /// void main() async {
+  ///   final ioWebSocket = await WebSocket.connect('<url>', protocols: [
+  ///     'chatV1',
+  ///     'chatV2',
+  ///   ], headers: {
+  ///     'authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXV',
+  ///   }).timeout(const Duration(milliseconds: 500));
+  ///
+  ///   ioWebSocket.pingInterval = const Duration(seconds: 10);
+  ///
+  ///   final channel =
+  ///       AdapterWebSocketChannel(IOWebSocket.fromWebSocket(ioWebSocket));
+  ///
+  ///   await channel.ready;
+  ///
+  ///   // Use the `WebSocketChannel`.
+  /// }
+  /// ```
+  @Deprecated('Use IOWebSocket with AdapterWebSocketChannel')
   IOWebSocketChannel(FutureOr<WebSocket> webSocket)
       : super(webSocket is Future<WebSocket>
             ? webSocket.then(IOWebSocket.fromWebSocket) as FutureOr<IOWebSocket>


### PR DESCRIPTION
- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
