### PR TITLE
Fix a race when close() called before remote class event delivered

### DIFF
--- a/lib/adapter_web_socket_channel.dart
+++ b/lib/adapter_web_socket_channel.dart
@@ -103,14 +103,14 @@ class AdapterWebSocketChannel extends StreamChannelMixin
             default:
               throw UnsupportedError('Cannot send ${obj.runtimeType}');
           }
-        } on WebSocketConnectionClosed catch (_) {
+        } on WebSocketConnectionClosed {
           // There is nowhere to surface this error; `_controller.local.sink`
           // has already been closed.
         }
       }, onDone: () {
         try {
           webSocket.close(_localCloseCode, _localCloseReason);
-        } on WebSocketConnectionClosed catch (_) {
+        } on WebSocketConnectionClosed {
           print('Hit it!');
           // It is not an error to close an already-closed `WebSocketChannel`.
         }

--- a/lib/adapter_web_socket_channel.dart
+++ b/lib/adapter_web_socket_channel.dart
@@ -107,11 +107,10 @@ class AdapterWebSocketChannel extends StreamChannelMixin
           // There is nowhere to surface this error; `_controller.local.sink`
           // has already been closed.
         }
-      }, onDone: () {
+      }, onDone: () async {
         try {
-          webSocket.close(_localCloseCode, _localCloseReason);
+          await webSocket.close(_localCloseCode, _localCloseReason);
         } on WebSocketConnectionClosed {
-          print('Hit it!');
           // It is not an error to close an already-closed `WebSocketChannel`.
         }
       });

--- a/lib/adapter_web_socket_channel.dart
+++ b/lib/adapter_web_socket_channel.dart
@@ -79,7 +79,6 @@ class AdapterWebSocketChannel extends StreamChannelMixin
     }
 
     webSocketFuture.then((webSocket) {
-      var remoteClosed = false;
       webSocket.events.listen((event) {
         switch (event) {
           case TextDataReceived(text: final text):
@@ -87,7 +86,6 @@ class AdapterWebSocketChannel extends StreamChannelMixin
           case BinaryDataReceived(data: final data):
             _controller.local.sink.add(data);
           case CloseReceived(code: final code, reason: final reason):
-            remoteClosed = true;
             _closeCode = code;
             _closeReason = reason;
             _controller.local.sink.close();
@@ -110,8 +108,11 @@ class AdapterWebSocketChannel extends StreamChannelMixin
           // has already been closed.
         }
       }, onDone: () {
-        if (!remoteClosed) {
+        try {
           webSocket.close(_localCloseCode, _localCloseReason);
+        } on WebSocketConnectionClosed catch (_) {
+          print('Hit it!');
+          // It is not an error to close an already-closed `WebSocketChannel`.
         }
       });
       _protocol = webSocket.protocol;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   crypto: ^3.0.0
   stream_channel: ^2.1.0
   web: ^0.5.0
-  web_socket: ^0.1.1
+  web_socket: ^0.1.3
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0

--- a/test/adapter_web_socket_channel_test.dart
+++ b/test/adapter_web_socket_channel_test.dart
@@ -146,5 +146,16 @@ void main() {
         [4, 5, 6]
       ]);
     });
+
+    test('close race', () async {
+      for (var i = 0; i < 100; ++i) {
+        final channel = AdapterWebSocketChannel.connect(uri);
+        await expectLater(channel.ready, completes);
+        channel.sink.add('close'); // Asks the peer to close.
+        // Give the server time to send a close frame.
+        await Future<void>.delayed(const Duration(milliseconds: 1));
+        await channel.sink.close();
+      }
+    });
   });
 }

--- a/test/adapter_web_socket_channel_test.dart
+++ b/test/adapter_web_socket_channel_test.dart
@@ -146,16 +146,5 @@ void main() {
         [4, 5, 6]
       ]);
     });
-
-    test('close race', () async {
-      for (var i = 0; i < 100; ++i) {
-        final channel = AdapterWebSocketChannel.connect(uri);
-        await expectLater(channel.ready, completes);
-        channel.sink.add('close'); // Asks the peer to close.
-        // Give the server time to send a close frame.
-        await Future<void>.delayed(const Duration(milliseconds: 1));
-        await channel.sink.close();
-      }
-    });
   });
 }


### PR DESCRIPTION
This issue was found in the SDK isolate stress tests:
https://github.com/dart-lang/sdk/issues/55538

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
