### PR TITLE
Make shelf_web_socket a dev dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0
+  shelf_web_socket: any
   test: ^1.16.0
 
 # Remove this when versions of `package:test` and `shelf_web_socket` that support


### PR DESCRIPTION
Works around this issue:
```
Hey, I'm trying to release package:web_socket_channel:
dependency_overrides:
  shelf_web_socket:
    git:
      ref: master
      url: https://github.com/dart-lang/shelf.git
      path: pkgs/shelf_web_socket
  test: 1.25.2
package:shelf_web_socket:
dependency_overrides:
  test: 1.25.2
And package:test

When I try to publish web_socket_channel, I get a warning that says: 
* Non-dev dependencies are overridden in pubspec.yaml.

  This indicates you are not testing your package against the same versions of its
  dependencies that users will have when they use it.

  This might be necessary for packages with cyclic dependencies.

  Please be extra careful when publishing.
My intent is to force the head version of shelf_web_socket to be used when running the web_socket_channel unit tests.
```


---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
