### PR TITLE
Remove dependency_overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+- Remove unnecessary `dependency_overrides`.
+
 ## 3.0.0
 
 - Provide an adapter around `package:web_socket` `WebSocket`s and make it the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.0.1
+## 3.0.1-wip
 
 - Remove unnecessary `dependency_overrides`.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: web_socket_channel
-version: 3.0.0
+version: 3.0.1-wip
 description: >-
   StreamChannel wrappers for WebSockets. Provides a cross-platform
   WebSocketChannel API, a cross-platform implementation of that API that
@@ -18,15 +18,4 @@ dependencies:
 
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0
-  shelf_web_socket: any
-  test: ^1.16.0
-
-# Remove this when versions of `package:test` and `shelf_web_socket` that support
-# channel_web_socket 3.0 are released.
-dependency_overrides:
-  shelf_web_socket:
-    git: 
-      ref: master
-      url: https://github.com/dart-lang/shelf.git
-      path: pkgs/shelf_web_socket
-  test: 1.25.2
+  test: ^1.25.2


### PR DESCRIPTION
- They are no longer needed now that `package:test` 1.25.2 is released.

---

- [X] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
