### PR TITLE
Add `topics` to `pubspec.yaml`

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,3 +19,7 @@ dependencies:
 dev_dependencies:
   dart_flutter_team_lints: ^2.0.0
   test: ^1.25.2
+
+topics:
+ - web
+ - http


### PR DESCRIPTION
Topics help users on pub.dev discover packages, and related packages.

You can see a list of [topics here](https://pub.dev/topics).
You can also make your own topics.

Topics are added to pubspec.yaml as follows:

```
topics:
 - my-topic
 - some-other-topic
```
See also: https://dart.dev/tools/pub/pubspec#topics