### PR TITLE
Remove obsolete `WebSocketChannel.new` documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 3.0.1-wip
 
 - Remove unnecessary `dependency_overrides`.
+- Remove obsolete documentation for `WebSocketChannel.new`.
 
 ## 3.0.0
 

--- a/README.md
+++ b/README.md
@@ -64,19 +64,3 @@ other socket exactly why they're closing the connection.
 [sink]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel/sink.html
 [WebSocketSink]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketSink-class.html
 [sink.close]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketSink/close.html
-
-`WebSocketChannel` also works as a cross-platform implementation of the
-WebSocket protocol. The [`WebSocketChannel.connect` constructor][connect]
-connects to a listening server using the appropriate implementation for the
-platform. The [`WebSocketChannel()` constructor][new] takes an underlying
-[`StreamChannel`][stream_channel] over which it communicates using the WebSocket
-protocol. It also provides the static [`signKey()`][signKey] method to make it
-easier to implement the [initial WebSocket handshake][]. These are used in the
-[`shelf_web_socket`][shelf_web_socket] package to support WebSockets in a
-cross-platform way.
-
-[connect]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel/WebSocketChannel.connect.html
-[new]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel/WebSocketChannel.html
-[signKey]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel/signKey.html
-[initial WebSocket handshake]: https://tools.ietf.org/html/rfc6455#section-4.2.2
-[shelf_web_socket]: https://pub.dev/packages/shelf_web_socket

--- a/README.md
+++ b/README.md
@@ -64,3 +64,10 @@ other socket exactly why they're closing the connection.
 [sink]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel/sink.html
 [WebSocketSink]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketSink-class.html
 [sink.close]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketSink/close.html
+
+`WebSocketChannel` also works as a cross-platform implementation of the
+WebSocket protocol. The [`WebSocketChannel.connect` constructor][connect]
+connects to a listening server using the appropriate implementation for the
+platform.
+
+[connect]: https://pub.dev/documentation/web_socket_channel/latest/web_socket_channel/WebSocketChannel/WebSocketChannel.connect.html


### PR DESCRIPTION
Fixes https://github.com/dart-lang/web_socket_channel/issues/358

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
