### PR TITLE
Bump web_socket dependency 0.1.3 -> 0.1.5

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
   crypto: ^3.0.0
   stream_channel: ^2.1.0
   web: ^0.5.0
-  web_socket: ^0.1.3
+  web_socket: ^0.1.5
 
 dev_dependencies:
   dart_flutter_team_lints: ^3.0.0


### PR DESCRIPTION
Fixes #355 

Simply allow code 1000 like it should be by using the fix in web_socket dependency's last version 1.0.5

See  https://pub.dev/packages/web_socket/changelog


- [x] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/wiki/External-Package-Maintenance#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
